### PR TITLE
Ffmpeg audio

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [scripts]
 avi_jp2_convert = 'bin/avi_jp2_convert'
 avi_ffmpeg_thumbnail = 'bin/avi_ffmpeg_thumbnail'
+avi_ffmpeg_mp3 = 'bin/avi_ffmpeg_mp3'
 
 [packages]
 opencv-python = ">3.4"

--- a/avi_py/__init__.py
+++ b/avi_py/__init__.py
@@ -1,5 +1,5 @@
 """avi_py."""
-__version__ = "0.2"
+__version__ = "0.3"
 __author__ = "Benjamin Barber (bbarber@bpl.org)"
 #pylint: disable=wrong-import-position
 import logging
@@ -7,5 +7,5 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 from .entry_points import convert_jp2_main, ffmpeg_thumbnail_main
 
-__all__ = ['convert_jp2_main', 'ffmpeg_thumbnail_main']
+__all__ = ['convert_jp2_main', 'ffmpeg_thumbnail_main', 'ffmpeg_mp3_main']
 #pylint: enable=wrong-import-position

--- a/avi_py/__init__.py
+++ b/avi_py/__init__.py
@@ -5,7 +5,7 @@ __author__ = "Benjamin Barber (bbarber@bpl.org)"
 import logging
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-from .entry_points import convert_jp2_main, ffmpeg_thumbnail_main
+from .entry_points import convert_jp2_main, ffmpeg_thumbnail_main, ffmpeg_mp3_main
 
 __all__ = ['convert_jp2_main', 'ffmpeg_thumbnail_main', 'ffmpeg_mp3_main']
 #pylint: enable=wrong-import-position

--- a/avi_py/avi_audio_data.py
+++ b/avi_py/avi_audio_data.py
@@ -1,0 +1,45 @@
+import os
+import errno
+
+from pathlib import Path
+from typing import Union, List
+
+import ffmpeg
+
+from . import constants as avi_const
+from .avi_ffprobe_data import AviFfprobeData
+
+class AviAudioData(AviFfprobeData):
+    """
+    Class for storing all low level video data for functions that are used for
+    creating video deriavtives with FFMpeg
+    """
+    def __init__(self, audio_src_path: Union[str, Path]) -> None:
+        self.audio_src_path = audio_src_path
+        super().__init__(audio_src_path)
+
+    @property
+    def audio_src_path(self) -> Path:
+        return self.__audio_src_path
+
+    @audio_src_path.setter
+    def audio_src_path(self, audio_src_path: Union[str, Path]) -> None:
+        if not isinstance(audio_src_path, Path):
+            audio_src_path = Path(audio_src_path)
+        if not audio_src_path.exists() or not audio_src_path.is_file():
+            raise FileNotFoundError(
+                    errno.ENOENT, os.strerror(errno.ENOENT), str(audio_src_path))
+        self.__audio_src_path = audio_src_path
+
+    @property
+    def audio_streams(self) -> List[dict]:
+        return [stream for stream in self.ffprobe_streams if stream['codec_type'] == 'audio']
+
+    @property
+    def audio_ext(self) -> str:
+        return self.audio_src_path.suffix
+
+    def valid_audio_ext(self) -> bool:
+        return self.audio_ext in avi_const.VALID_AUDIO_EXTENSIONS
+
+__all__ = ['AviAudioData']

--- a/avi_py/avi_audio_data.py
+++ b/avi_py/avi_audio_data.py
@@ -4,12 +4,10 @@ import errno
 from pathlib import Path
 from typing import Union, List
 
-import ffmpeg
-
 from . import constants as avi_const
-from .avi_ffprobe_data import AviFfprobeData
+from .avi_ffprobe_data import AviFFProbeData
 
-class AviAudioData(AviFfprobeData):
+class AviAudioData(AviFFProbeData):
     """
     Class for storing all low level video data for functions that are used for
     creating video deriavtives with FFMpeg

--- a/avi_py/avi_ffmpeg_processor.py
+++ b/avi_py/avi_ffmpeg_processor.py
@@ -78,7 +78,7 @@ class AviFFMpegProcessor:
         try:
             if self.audio_data is None:
                 raise AviFFMpegProcessorError('Source Audio Data is None. Did you mean to call generate_mp3?')
-            elif not self.audio_data.valid_audio_ext():
+            if not self.audio_data.valid_audio_ext():
                 raise AviFFMpegProcessorError('Source audio is not a .wav')
             self._ffmpeg_mp3()
             self.__set_success_result()
@@ -92,7 +92,7 @@ class AviFFMpegProcessor:
         try:
             if self.video_data is None:
                 raise AviFFMpegProcessorError('Source Video Data is None. Did you mean to call generate_mp3?')
-            elif not self.video_data.valid_video_ext():
+            if not self.video_data.valid_video_ext():
                 raise AviFFMpegProcessorError('Source video is not a .mov or .mp4')
             with tempfile.NamedTemporaryFile(prefix='avi_py-ffmpeg-thumb_', suffix='.jpg') as ffmpeg_jpeg:
                 self._ffmpeg_thumbnail(ffmpeg_jpeg.name)

--- a/avi_py/avi_ffmpeg_processor.py
+++ b/avi_py/avi_ffmpeg_processor.py
@@ -14,6 +14,7 @@ from PIL import Image
 
 from . import constants as avi_const
 from .avi_video_data import AviVideoData
+from .avi_audio_data import AviAudioData
 
 #pylint: disable=missing-class-docstring
 class AviFFMpegProcessorError(Exception):
@@ -24,17 +25,28 @@ class AviFFMpegProcessor:
     """
     Class that checks and converts a source video file thumbnail derivative
     """
-    def __init__(self, src_file_path: Union[str, Path], dest_file_path: Union[str, Path]) -> None:
+    def __init__(self, src_file_path: Union[str, Path], dest_file_path: Union[str, Path], is_video: bool=True) -> None:
         self.success = False
         self.result_message = ''
         self.dest_file_path = dest_file_path
-        self.video_data = AviVideoData(src_file_path)
+        if is_video:
+            self.video_data = AviVideoData(src_file_path)
+            self.audio_data = None
+        else:
+            self.audio_data = AviAudioData(src_file_path)
+            self.video_data = None
         self.logger = logging.getLogger('avi_py')
 
     @classmethod
-    def process_thumbnail(cls, src_file_path: Union[str, Path], dest_file_path: Union[str, Path]) -> AviFFMpegProcessor:
-        ffmpeg_processor = cls(src_file_path, dest_file_path)
+    def process_thumbnail(cls, src_file_path: Union[str, Path], dest_file_path: Union[str, Path], is_video: bool=True) -> AviFFMpegProcessor:
+        ffmpeg_processor = cls(src_file_path, dest_file_path, is_video)
         ffmpeg_processor.generate_thumbnail()
+        return ffmpeg_processor
+
+    @classmethod
+    def process_mp3(cls, src_file_path: Union[str, Path], dest_file_path: Union[str, Path], is_video: bool=False) -> AviFFMpegProcessor:
+        ffmpeg_processor = cls(src_file_path, dest_file_path, is_video)
+        ffmpeg_processor.generate_mp3()
         return ffmpeg_processor
 
     @property
@@ -62,9 +74,25 @@ class AviFFMpegProcessor:
     def json_result(self) -> str:
         return json.dumps(self.result)
 
+    def generate_mp3(self) -> None:
+        try:
+            if self.audio_data is None:
+                raise AviFFMpegProcessorError('Source Audio Data is None. Did you mean to call generate_mp3?')
+            elif not self.audio_data.valid_audio_ext():
+                raise AviFFMpegProcessorError('Source audio is not a .wav')
+            self._ffmpeg_mp3()
+            self.__set_success_result()
+        except AviFFMpegProcessorError as avi_ex:
+            msg = str(avi_ex)
+            self.__set_error_result(msg)
+            self.logger.error('Error Occured processing file for ffmpeg audio mp3 derivative!')
+            self.logger.error('Check result and logs to see additional details')
+
     def generate_thumbnail(self) -> None:
         try:
-            if not self.video_data.valid_video_ext():
+            if self.video_data is None:
+                raise AviFFMpegProcessorError('Source Video Data is None. Did you mean to call generate_mp3?')
+            elif not self.video_data.valid_video_ext():
                 raise AviFFMpegProcessorError('Source video is not a .mov or .mp4')
             with tempfile.NamedTemporaryFile(prefix='avi_py-ffmpeg-thumb_', suffix='.jpg') as ffmpeg_jpeg:
                 self._ffmpeg_thumbnail(ffmpeg_jpeg.name)
@@ -72,7 +100,7 @@ class AviFFMpegProcessor:
         except AviFFMpegProcessorError as avi_ex:
             msg = str(avi_ex)
             self.__set_error_result(msg)
-            self.logger.error('Error Occured processing file for ffmpeg thumbnail!')
+            self.logger.error('Error Occured processing file for ffmpeg video thumbnail derivative!')
             self.logger.error('Check result and logs to see additional details')
 
     def _ffmpeg_thumbnail(self, out_file_path: str) -> None:
@@ -88,17 +116,32 @@ class AviFFMpegProcessor:
             msg = f'{ex.__class__.__name__} {ex}'
             raise AviFFMpegProcessorError(msg) from ex
 
+    def _ffmpeg_mp3(self) -> None:
+        try:
+            ffmpeg \
+                .input(str(self.audio_data.audio_src_path)) \
+                .output(str(self.dest_file_path),**avi_const.FFMPEG_AUDIO_ARGS) \
+                .overwrite_output() \
+                .run(capture_stdout=avi_const.CONSOLE_DEBUG_MODE, capture_stderr=True)
+        except ffmpeg.Error as ff_ex:
+            msg = 'Ffmpeg Error! {}'.format(ff_ex.stderr.decode())
+            raise AviFFMpegProcessorError(msg) from ff_ex
+        except Exception as ex:
+            msg = f'{ex.__class__.__name__} {ex}'
+            raise AviFFMpegProcessorError(msg) from ex
+
+
     def __ffmpeg_downscale_screen_grab(self, out_file_path: str) -> None:
         ffmpeg \
-        .input(str(self.video_data.video_src_path), ss=self.video_data.ss_time()) \
-        .filter('scale', -1, 360, force_original_aspect_ratio='decrease') \
-        .output(out_file_path, vframes=1, vcodec='mjpeg') \
-        .overwrite_output() \
-        .run(capture_stdout=avi_const.CONSOLE_DEBUG_MODE, capture_stderr=True)
+            .input(str(self.video_data.video_src_path), ss=self.video_data.ss_time()) \
+            .filter('scale', -1, 360, force_original_aspect_ratio='decrease') \
+            .output(out_file_path, vframes=1, vcodec='mjpeg') \
+            .overwrite_output() \
+            .run(capture_stdout=avi_const.CONSOLE_DEBUG_MODE, capture_stderr=True)
 
     def __set_success_result(self) -> None:
         self.success = True
-        self.result_message = f'Successfully created thumbnail at {self.dest_file_path}'
+        self.result_message = f'Successfully created ffmpeg derivative at {self.dest_file_path}'
 
     def __set_error_result(self, error_msg: str='') -> None:
         self.success = False

--- a/avi_py/avi_ffprobe_data.py
+++ b/avi_py/avi_ffprobe_data.py
@@ -1,0 +1,44 @@
+import ffmpeg
+
+from pathlib import Path
+from typing import Union, List
+
+class AviFfprobeData:
+    """
+    Base Class for storing all low level audio/video data for functions that are used for
+    creating audio/video deriavtives with ffprobe
+    """
+    def __init__(self, src_file_path: Union[str, Path]) -> None:
+        self.ffmpeg_probe = ffmpeg.probe(src_file_path)
+
+    @property
+    def ffmpeg_probe(self) -> dict:
+        return self.__ffmpeg_probe
+
+    @ffmpeg_probe.setter
+    def ffmpeg_probe(self, ffprobe: dict) -> None:
+        self.__ffmpeg_probe = ffprobe
+
+    @property
+    def ffprobe_streams(self) -> List[dict]:
+        if 'streams' in self.ffmpeg_probe.keys():
+            return self.ffmpeg_probe['streams']
+        return []
+
+    @property
+    def ffprobe_format(self) -> dict:
+        if 'format' in self.ffmpeg_probe.keys():
+            return self.ffmpeg_probe['format']
+        return {}
+
+    # The following two properties should be included by default in inherited classes
+    @property
+    def raw_stream(self) -> dict:
+        return next((stream for stream in self.ffprobe_streams if stream['codec_type'] == 'data'), {})
+
+    # NOTE: More than one audio channel
+    @property
+    def audio_streams(self) -> List[dict]:
+        return [stream for stream in self.ffprobe_streams if stream['codec_type'] == 'audio']
+
+__all__ = ['AviFfprobeData']

--- a/avi_py/avi_ffprobe_data.py
+++ b/avi_py/avi_ffprobe_data.py
@@ -1,9 +1,9 @@
-import ffmpeg
-
 from pathlib import Path
 from typing import Union, List
 
-class AviFfprobeData:
+import ffmpeg
+
+class AviFFProbeData:
     """
     Base Class for storing all low level audio/video data for functions that are used for
     creating audio/video deriavtives with ffprobe
@@ -41,4 +41,4 @@ class AviFfprobeData:
     def audio_streams(self) -> List[dict]:
         return [stream for stream in self.ffprobe_streams if stream['codec_type'] == 'audio']
 
-__all__ = ['AviFfprobeData']
+__all__ = ['AviFFProbeData']

--- a/avi_py/avi_video_data.py
+++ b/avi_py/avi_video_data.py
@@ -7,15 +7,16 @@ from typing import Union, List
 import ffmpeg
 
 from . import constants as avi_const
+from .avi_ffprobe_data import AviFfprobeData
 
-class AviVideoData:
+class AviVideoData(AviFfprobeData):
     """
     Class for storing all low level video data for functions that are used for
     creating video deriavtives with FFMpeg
     """
     def __init__(self, video_src_path: Union[str, Path]) -> None:
         self.video_src_path = video_src_path
-        self.ffmpeg_probe = ffmpeg.probe(video_src_path)
+        super().__init__(video_src_path)
 
     @property
     def video_src_path(self) -> Path:
@@ -31,37 +32,8 @@ class AviVideoData:
         self.__video_src_path = video_src_path
 
     @property
-    def ffmpeg_probe(self) -> dict:
-        return self.__ffmpeg_probe
-
-    @ffmpeg_probe.setter
-    def ffmpeg_probe(self, ffprobe: dict) -> None:
-        self.__ffmpeg_probe = ffprobe
-
-    @property
-    def ffprobe_streams(self) -> List[dict]:
-        if 'streams' in self.ffmpeg_probe.keys():
-            return self.ffmpeg_probe['streams']
-        return []
-
-    @property
-    def ffprobe_format(self) -> dict:
-        if 'format' in self.ffmpeg_probe.keys():
-            return self.ffmpeg_probe['format']
-        return {}
-
-    @property
     def video_stream(self) -> dict:
         return next((stream for stream in self.ffprobe_streams if stream['codec_type'] == 'video'), {})
-
-    # NOTE: More than one audio channel
-    @property
-    def audio_streams(self) -> List[dict]:
-        return [stream for stream in self.ffprobe_streams if stream['codec_type'] == 'audio']
-
-    @property
-    def raw_stream(self) -> dict:
-        return next((stream for stream in self.ffprobe_streams if stream['codec_type'] == 'data'), {})
 
     @property
     def video_ext(self) -> str:

--- a/avi_py/avi_video_data.py
+++ b/avi_py/avi_video_data.py
@@ -2,14 +2,12 @@ import os
 import errno
 
 from pathlib import Path
-from typing import Union, List
-
-import ffmpeg
+from typing import Union
 
 from . import constants as avi_const
-from .avi_ffprobe_data import AviFfprobeData
+from .avi_ffprobe_data import AviFFProbeData
 
-class AviVideoData(AviFfprobeData):
+class AviVideoData(AviFFProbeData):
     """
     Class for storing all low level video data for functions that are used for
     creating video deriavtives with FFMpeg

--- a/avi_py/constants.py
+++ b/avi_py/constants.py
@@ -10,6 +10,7 @@ EXIFTOOL_PATH=os.getenv('EXIFTOOL_PATH', 'exiftool')
 COLOR_MODES=['RGB', 'RGBA']
 VALID_IMAGE_EXTENSIONS=['.tiff', '.tif']
 VALID_VIDEO_EXTENSIONS=['.mov', '.mp4', '.avi']
+VALID_AUDIO_EXTENSIONS=['.wav']
 
 KDU_DEFAULT_LAYER_COUNT=8
 KDU_DEFAULT_TILE_SIZE=1024
@@ -19,6 +20,8 @@ IMAGE_MAX_LEVEL_SIZE=96
 # Get screenshot five seconds into video
 FFMPEG_DEFAULT_SS_TIME=5
 FFMPEG_THUMBNAIL_SIZE=(300, 300)
+
+FFMPEG_AUDIO_ARGS={'ar': '44100', 'ac': 2, 'audio_bitrate': '192k', 'acodec': 'libmp3lame', 'f': 'mp3'}
 
 KAKADU_DEFAULT_OPTIONS=[
     '-num_threads', str(os.cpu_count()),

--- a/avi_py/entry_points.py
+++ b/avi_py/entry_points.py
@@ -11,8 +11,9 @@ __LOG_FORMAT = logging.Formatter("%(asctime)s [%(threadName)-12.12s] [%(levelnam
 __DEFAULT_LOG_PATH = str(Path.cwd() / 'logs' / 'avi_convert_jp2.log')
 __JP2_PARSER_DESC = "Generate a JP2 from a TIFF. Adds sRGB_IEC61966-2-1_no_black_scaling icc profile if is color. Prevalidates image before conversion"
 __FFMPEG_THUMB_PARSER_DESC = "Generate a 300x300 pixel thumbnail from a given .mov or .mp4 file"
+__FFMPEG_AUDIO_PARSER_DESC = "Generate a mp3 from a given .wav file"
 
-__all__ = ['convert_jp2_main', 'ffmpeg_thumbnail_main']
+__all__ = ['convert_jp2_main', 'ffmpeg_thumbnail_main', 'ffmpeg_mp3_main']
 
 def convert_jp2_main() -> None:
     """
@@ -51,6 +52,23 @@ def ffmpeg_thumbnail_main() -> None:
     except FileNotFoundError as f_ex:
         sys.exit("Error! {}".format(str(f_ex)))
 
+def ffmpeg_mp3_main() -> None:
+    """
+    A basic command line script that runs :func:`~avi_py.avi_ffmpeg_processor.AviFFMpegProcessor.process_mp3`"
+    """
+    args = __parse_ffmpeg_mp3_args()
+    __setup_logger(args.log_file, args.log_level)
+
+    try:
+        ffmpeg_thumb = AviFFMpegProcessor.process_mp3(args.src_file_path, args.dest_file_path)
+        json_result = ffmpeg_thumb.json_result()
+        if ffmpeg_thumb.success:
+            print("{}".format(json_result), end='')
+        else:
+            sys.exit("Error! {}".format(json_result))
+    except FileNotFoundError as f_ex:
+        sys.exit("Error! {}".format(str(f_ex)))
+
 def __setup_logger(log_file: str, log_level_name: str='debug') -> None:
     """
     Sets up the logger. Writes to console as well a file if AVI_DEBUG=true
@@ -81,9 +99,17 @@ def __parse_ffmpeg_thumbnail_args(parser: ArgumentParser=ArgumentParser(prog='av
     parser.add_argument('-Ll', '--log_level', type=str, help='Log level[debug|info|warning|error|critical]', required=False, default='DEBUG')
     return parser.parse_args()
 
+def __parse_ffmpeg_mp3_args(parser: ArgumentParser=ArgumentParser(prog='avi_ffmpeg_mp3',
+                                            description=__FFMPEG_AUDIO_PARSER_DESC)) -> Namespace:
+    parser.add_argument('src_file_path', type=str, help='Full path to the source wav file to covert')
+    parser.add_argument('dest_file_path', type=str, help='Path to mp3 thumbnail output file')
+    parser.add_argument('-Lf', '--log_file', type=str, help='Path to a log file to output', required=False, default=__DEFAULT_LOG_PATH)
+    parser.add_argument('-Ll', '--log_level', type=str, help='Log level[debug|info|warning|error|critical]', required=False, default='DEBUG')
+    return parser.parse_args()
+
 def __parse_jp2_args(parser: ArgumentParser=ArgumentParser(prog='avi_jp2_convert',
                                             description=__JP2_PARSER_DESC)) -> Namespace:
-    parser.add_argument('src_file_path', type=str, help='Full path to the source mov or mp4 file to covert')
+    parser.add_argument('src_file_path', type=str, help='Full path to the source tif file to covert')
     parser.add_argument('dest_file_path', type=str, help='Path to jp2 output file')
     parser.add_argument('-Lf', '--log_file', type=str, help='Path to a log file to output', required=False, default=__DEFAULT_LOG_PATH)
     parser.add_argument('-Ll', '--log_level', type=str, help='Log level[debug|info|warning|error|critical]', required=False, default='debug')

--- a/bin/avi_ffmpeg_mp3
+++ b/bin/avi_ffmpeg_mp3
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+from pathlib import Path
+
+_project_root = str(Path.cwd())
+sys.path.insert(0, _project_root)
+
+from avi_py import ffmpeg_mp3_main
+
+if __name__ == '__main__':
+    ffmpeg_mp3_main()

--- a/tests/file_fixtures.py
+++ b/tests/file_fixtures.py
@@ -1,10 +1,9 @@
 import errno
 import os
-import pytest
 
 from pathlib import Path
-from PIL import Image
 from contextlib import contextmanager
+from PIL import Image
 from avi_py import constants as avi_const
 
 TEST_FILE_DIR=avi_const.PROJECT_ROOT / 'tests' / 'data'
@@ -19,9 +18,9 @@ WAV_AUDIO=str(TEST_FILE_DIR / 'audio-test.wav')
 
 @contextmanager
 def image_fixture(img_path):
-    p = Path(str(img_path))
-    if not p.is_file():
+    path = Path(str(img_path))
+    if not path.is_file():
         raise FileNotFoundError(
                 errno.ENOENT, os.strerror(errno.ENOENT), str(img_path))
-    with Image.open(p) as img_fixture:
+    with Image.open(path) as img_fixture:
         yield img_fixture

--- a/tests/file_fixtures.py
+++ b/tests/file_fixtures.py
@@ -15,6 +15,8 @@ SRGB_IMAGE=str(TEST_FILE_DIR / 'srgb_image.tiff')
 MP4_VIDEO=str(TEST_FILE_DIR / 'mlk.mp4')
 MOV_VIDEO=str(TEST_FILE_DIR / 'mlk.mov')
 
+WAV_AUDIO=str(TEST_FILE_DIR / 'audio-test.wav')
+
 @contextmanager
 def image_fixture(img_path):
     p = Path(str(img_path))

--- a/tests/test_avi_audio_data.py
+++ b/tests/test_avi_audio_data.py
@@ -1,0 +1,59 @@
+import logging
+import pytest
+import os
+import sys
+from pathlib import Path
+
+from avi_py.avi_ffprobe_data import AviFfprobeData
+from avi_py.avi_audio_data import AviAudioData
+from avi_py import constants as avi_const
+from . import file_fixtures
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+
+def get_audio_data(audio_src_path) -> AviAudioData:
+    return AviAudioData(video_src_path)
+
+@pytest.fixture
+def wav_audio_data() -> AviAudioData:
+    return AviAudioData(file_fixtures.WAV_AUDIO)
+
+
+class TestAviAudioData:
+    def test_wav_audio_data(self, wav_audio_data):
+        assert bool(wav_audio_data) is True
+        assert isinstance(wav_audio_data, AviAudioData)
+        assert issubclass(wav_audio_data.__class__, AviFfprobeData)
+        assert isinstance(wav_audio_data.audio_src_path, Path)
+
+        assert str(wav_audio_data.audio_src_path) == file_fixtures.WAV_AUDIO
+
+        assert isinstance(wav_audio_data.audio_ext, str)
+        assert wav_audio_data.audio_ext == '.wav'
+        assert wav_audio_data.valid_audio_ext() is True
+
+        assert bool(wav_audio_data.ffmpeg_probe) is True
+        assert isinstance(wav_audio_data.ffmpeg_probe, dict)
+
+        for key in ['format', 'streams']:
+            assert key in wav_audio_data.ffmpeg_probe.keys()
+
+        assert bool(wav_audio_data.ffprobe_format) is True
+        assert isinstance(wav_audio_data.ffprobe_format, dict)
+
+        assert bool(wav_audio_data.ffprobe_streams) is True
+        assert isinstance(wav_audio_data.ffprobe_streams, list)
+
+        for stream in wav_audio_data.ffprobe_streams:
+            assert bool(stream) is True
+            assert isinstance(stream, dict)
+
+        assert bool(wav_audio_data.audio_streams) is True
+        assert isinstance(wav_audio_data.audio_streams, list)
+
+        assert wav_audio_data.raw_stream is not None
+        assert isinstance(wav_audio_data.raw_stream, dict)
+
+        for audio_stream in wav_audio_data.audio_streams:
+            assert bool(audio_stream) is True
+            assert isinstance(audio_stream, dict)

--- a/tests/test_avi_audio_data.py
+++ b/tests/test_avi_audio_data.py
@@ -1,29 +1,31 @@
 import logging
-import pytest
-import os
 import sys
 from pathlib import Path
 
-from avi_py.avi_ffprobe_data import AviFfprobeData
+import pytest
+
+from avi_py.avi_ffprobe_data import AviFFProbeData
 from avi_py.avi_audio_data import AviAudioData
-from avi_py import constants as avi_const
 from . import file_fixtures
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 def get_audio_data(audio_src_path) -> AviAudioData:
-    return AviAudioData(video_src_path)
+    return AviAudioData(audio_src_path)
 
-@pytest.fixture
-def wav_audio_data() -> AviAudioData:
-    return AviAudioData(file_fixtures.WAV_AUDIO)
+@pytest.fixture(name='wav_audio_data')
+def fixture_wav_audio_data() -> AviAudioData:
+    return get_audio_data(file_fixtures.WAV_AUDIO)
 
 
 class TestAviAudioData:
+    """
+    Unit tests for the AviAudioData class
+    """
     def test_wav_audio_data(self, wav_audio_data):
         assert bool(wav_audio_data) is True
         assert isinstance(wav_audio_data, AviAudioData)
-        assert issubclass(wav_audio_data.__class__, AviFfprobeData)
+        assert issubclass(wav_audio_data.__class__, AviFFProbeData)
         assert isinstance(wav_audio_data.audio_src_path, Path)
 
         assert str(wav_audio_data.audio_src_path) == file_fixtures.WAV_AUDIO

--- a/tests/test_avi_ffmpeg_processor.py
+++ b/tests/test_avi_ffmpeg_processor.py
@@ -1,11 +1,9 @@
 import logging
-import pytest
-import os
 import sys
 import json
-
 from tempfile import TemporaryDirectory, NamedTemporaryFile
-from pathlib import Path
+
+import pytest
 
 from avi_py.avi_video_data import AviVideoData
 from avi_py.avi_audio_data import AviAudioData
@@ -15,30 +13,31 @@ from . import file_fixtures
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
-@pytest.fixture(scope='module')
-def temp_folder(prefix='avi_test_video_files', dir='/tmp'):
-    temp_dir = TemporaryDirectory(prefix=prefix, dir=dir)
-    print(f'Created temp file at {temp_dir.name}')
-    yield temp_dir.name
-    temp_dir.cleanup()
+@pytest.fixture(scope='module', name='temp_folder')
+def fixture_temp_folder():
+    with TemporaryDirectory(prefix='avi_test_video_files', dir='/tmp') as temp_dir:
+        print(f'Created temp file at {temp_dir}')
+        yield temp_dir
 
-@pytest.fixture
-def thumbnail_dest_file(temp_folder):
-    dest_file = NamedTemporaryFile(dir=temp_folder, prefix='test-thumbnail-out', suffix='.jpg')
-    print(f'Created temp file at {dest_file.name}')
-    yield dest_file.name
-    dest_file.close()
+@pytest.fixture(name='thumbnail_dest_file')
+def fixture_thumbnail_dest_file(temp_folder):
+    with NamedTemporaryFile(dir=temp_folder, prefix='test-thumbnail-out', suffix='.jpg') as dest_file:
+        print(f'Created temp file at {dest_file.name}')
+        yield dest_file.name
 
-@pytest.fixture
-def mp3_destination_file(temp_folder):
-    dest_file = NamedTemporaryFile(dir=temp_folder, prefix='test-mp3-out', suffix='.mp3')
-    print(f'Created temp file at {dest_file.name}')
-    yield dest_file.name
-    dest_file.close()
+
+@pytest.fixture(name='mp3_destination_file')
+def fixture_mp3_destination_file(temp_folder):
+    with NamedTemporaryFile(dir=temp_folder, prefix='test-mp3-out', suffix='.mp3') as dest_file:
+        print(f'Created temp file at {dest_file.name}')
+        yield dest_file.name
 
 
 class TestAviFFMpegProcessor:
-    def test_mov_thumbnail_generation(self, temp_folder, thumbnail_dest_file):
+    """
+    Tests for processing mp3s and thumbnails for the AviFFMpegProcessor class
+    """
+    def test_mov_thumbnail_generation(self, thumbnail_dest_file):
         mov_ffmpeg_thumbnail = AviFFMpegProcessor.process_thumbnail(file_fixtures.MOV_VIDEO, thumbnail_dest_file)
 
         assert isinstance(mov_ffmpeg_thumbnail, AviFFMpegProcessor)
@@ -55,9 +54,7 @@ class TestAviFFMpegProcessor:
         assert mov_ffmpeg_thumbnail.result_message == f'Successfully created ffmpeg derivative at {thumbnail_dest_file}'
 
         assert bool(mov_ffmpeg_thumbnail.result) is True
-        for key in ['success', 'message']:
-            assert key in mov_ffmpeg_thumbnail.result.keys()
-
+        assert all(key in mov_ffmpeg_thumbnail.result for key in ['success', 'message'])
         assert mov_ffmpeg_thumbnail.success == mov_ffmpeg_thumbnail.result.get('success')
         assert mov_ffmpeg_thumbnail.result_message == mov_ffmpeg_thumbnail.result.get('message')
 
@@ -67,7 +64,7 @@ class TestAviFFMpegProcessor:
             assert mov_jpg.format =='JPEG'
             assert mov_jpg.width == 300
 
-    def test_mp4_thumbnail_generation(self, temp_folder, thumbnail_dest_file):
+    def test_mp4_thumbnail_generation(self, thumbnail_dest_file):
         mp4_ffmpeg_thumbnail = AviFFMpegProcessor.process_thumbnail(file_fixtures.MP4_VIDEO, thumbnail_dest_file)
 
         assert isinstance(mp4_ffmpeg_thumbnail, AviFFMpegProcessor)
@@ -84,8 +81,7 @@ class TestAviFFMpegProcessor:
         assert mp4_ffmpeg_thumbnail.result_message == f'Successfully created ffmpeg derivative at {thumbnail_dest_file}'
 
         assert bool(mp4_ffmpeg_thumbnail.result) is True
-        for key in ['success', 'message']:
-            assert key in mp4_ffmpeg_thumbnail.result.keys()
+        assert all(key in mp4_ffmpeg_thumbnail.result for key in ['success', 'message'])
 
         assert mp4_ffmpeg_thumbnail.success == mp4_ffmpeg_thumbnail.result.get('success')
         assert mp4_ffmpeg_thumbnail.result_message == mp4_ffmpeg_thumbnail.result.get('message')
@@ -96,7 +92,7 @@ class TestAviFFMpegProcessor:
             assert mp4_jpg.format =='JPEG'
             assert mp4_jpg.width == 300
 
-    def test_wav_mp3_generation(self, temp_folder, mp3_destination_file):
+    def test_wav_mp3_generation(self, mp3_destination_file):
         wav_ffmpeg_mp3 = AviFFMpegProcessor.process_mp3(file_fixtures.WAV_AUDIO, mp3_destination_file)
 
         assert isinstance(wav_ffmpeg_mp3, AviFFMpegProcessor)
@@ -113,9 +109,7 @@ class TestAviFFMpegProcessor:
         assert wav_ffmpeg_mp3.result_message == f'Successfully created ffmpeg derivative at {mp3_destination_file}'
 
         assert bool(wav_ffmpeg_mp3.result) is True
-        for key in ['success', 'message']:
-            assert key in wav_ffmpeg_mp3.result.keys()
-
+        assert all(key in wav_ffmpeg_mp3.result for key in ['success', 'message'])
         assert wav_ffmpeg_mp3.success == wav_ffmpeg_mp3.result.get('success')
         assert wav_ffmpeg_mp3.result_message == wav_ffmpeg_mp3.result.get('message')
 

--- a/tests/test_avi_ffmpeg_processor.py
+++ b/tests/test_avi_ffmpeg_processor.py
@@ -8,6 +8,7 @@ from tempfile import TemporaryDirectory, NamedTemporaryFile
 from pathlib import Path
 
 from avi_py.avi_video_data import AviVideoData
+from avi_py.avi_audio_data import AviAudioData
 from avi_py.avi_ffmpeg_processor import AviFFMpegProcessor
 
 from . import file_fixtures
@@ -23,27 +24,35 @@ def temp_folder(prefix='avi_test_video_files', dir='/tmp'):
 
 @pytest.fixture
 def thumbnail_dest_file(temp_folder):
-    dest_file = NamedTemporaryFile(dir=temp_folder, prefix='test-thumbnail-out',suffix='.jpg')
+    dest_file = NamedTemporaryFile(dir=temp_folder, prefix='test-thumbnail-out', suffix='.jpg')
+    print(f'Created temp file at {dest_file.name}')
+    yield dest_file.name
+    dest_file.close()
+
+@pytest.fixture
+def mp3_destination_file(temp_folder):
+    dest_file = NamedTemporaryFile(dir=temp_folder, prefix='test-mp3-out', suffix='.mp3')
     print(f'Created temp file at {dest_file.name}')
     yield dest_file.name
     dest_file.close()
 
 
 class TestAviFFMpegProcessor:
-    def test_mov_thumbnail(self, temp_folder, thumbnail_dest_file):
+    def test_mov_thumbnail_generation(self, temp_folder, thumbnail_dest_file):
         mov_ffmpeg_thumbnail = AviFFMpegProcessor.process_thumbnail(file_fixtures.MOV_VIDEO, thumbnail_dest_file)
 
         assert isinstance(mov_ffmpeg_thumbnail, AviFFMpegProcessor)
         assert isinstance(mov_ffmpeg_thumbnail.success, bool)
         assert isinstance(mov_ffmpeg_thumbnail.result_message, str)
-        assert isinstance(mov_ffmpeg_thumbnail.video_data, AviVideoData)
         assert isinstance(mov_ffmpeg_thumbnail.dest_file_path, str)
         assert isinstance(mov_ffmpeg_thumbnail.result, dict)
         assert isinstance(mov_ffmpeg_thumbnail.json_result(), str)
+        assert isinstance(mov_ffmpeg_thumbnail.video_data, AviVideoData)
 
+        assert mov_ffmpeg_thumbnail.audio_data is None
         assert mov_ffmpeg_thumbnail.dest_file_path == thumbnail_dest_file
         assert mov_ffmpeg_thumbnail.success is True
-        assert mov_ffmpeg_thumbnail.result_message == f'Successfully created thumbnail at {thumbnail_dest_file}'
+        assert mov_ffmpeg_thumbnail.result_message == f'Successfully created ffmpeg derivative at {thumbnail_dest_file}'
 
         assert bool(mov_ffmpeg_thumbnail.result) is True
         for key in ['success', 'message']:
@@ -58,19 +67,21 @@ class TestAviFFMpegProcessor:
             assert mov_jpg.format =='JPEG'
             assert mov_jpg.width == 300
 
-    def test_mp4_thumbnail(self, temp_folder, thumbnail_dest_file):
+    def test_mp4_thumbnail_generation(self, temp_folder, thumbnail_dest_file):
         mp4_ffmpeg_thumbnail = AviFFMpegProcessor.process_thumbnail(file_fixtures.MP4_VIDEO, thumbnail_dest_file)
 
         assert isinstance(mp4_ffmpeg_thumbnail, AviFFMpegProcessor)
         assert isinstance(mp4_ffmpeg_thumbnail.success, bool)
         assert isinstance(mp4_ffmpeg_thumbnail.result_message, str)
-        assert isinstance(mp4_ffmpeg_thumbnail.video_data, AviVideoData)
         assert isinstance(mp4_ffmpeg_thumbnail.dest_file_path, str)
         assert isinstance(mp4_ffmpeg_thumbnail.result, dict)
         assert isinstance(mp4_ffmpeg_thumbnail.json_result(), str)
+        assert isinstance(mp4_ffmpeg_thumbnail.video_data, AviVideoData)
+
+        assert mp4_ffmpeg_thumbnail.audio_data is None
         assert mp4_ffmpeg_thumbnail.dest_file_path == thumbnail_dest_file
         assert mp4_ffmpeg_thumbnail.success is True
-        assert mp4_ffmpeg_thumbnail.result_message == f'Successfully created thumbnail at {thumbnail_dest_file}'
+        assert mp4_ffmpeg_thumbnail.result_message == f'Successfully created ffmpeg derivative at {thumbnail_dest_file}'
 
         assert bool(mp4_ffmpeg_thumbnail.result) is True
         for key in ['success', 'message']:
@@ -84,3 +95,28 @@ class TestAviFFMpegProcessor:
         with file_fixtures.image_fixture(thumbnail_dest_file) as mp4_jpg:
             assert mp4_jpg.format =='JPEG'
             assert mp4_jpg.width == 300
+
+    def test_wav_mp3_generation(self, temp_folder, mp3_destination_file):
+        wav_ffmpeg_mp3 = AviFFMpegProcessor.process_mp3(file_fixtures.WAV_AUDIO, mp3_destination_file)
+
+        assert isinstance(wav_ffmpeg_mp3, AviFFMpegProcessor)
+        assert isinstance(wav_ffmpeg_mp3.success, bool)
+        assert isinstance(wav_ffmpeg_mp3.result_message, str)
+        assert isinstance(wav_ffmpeg_mp3.dest_file_path, str)
+        assert isinstance(wav_ffmpeg_mp3.result, dict)
+        assert isinstance(wav_ffmpeg_mp3.json_result(), str)
+        assert isinstance(wav_ffmpeg_mp3.audio_data, AviAudioData)
+
+        assert wav_ffmpeg_mp3.video_data is None
+        assert wav_ffmpeg_mp3.dest_file_path == mp3_destination_file
+        assert wav_ffmpeg_mp3.success is True
+        assert wav_ffmpeg_mp3.result_message == f'Successfully created ffmpeg derivative at {mp3_destination_file}'
+
+        assert bool(wav_ffmpeg_mp3.result) is True
+        for key in ['success', 'message']:
+            assert key in wav_ffmpeg_mp3.result.keys()
+
+        assert wav_ffmpeg_mp3.success == wav_ffmpeg_mp3.result.get('success')
+        assert wav_ffmpeg_mp3.result_message == wav_ffmpeg_mp3.result.get('message')
+
+        assert wav_ffmpeg_mp3.json_result() == json.dumps(wav_ffmpeg_mp3.result)

--- a/tests/test_avi_image_data.py
+++ b/tests/test_avi_image_data.py
@@ -1,8 +1,8 @@
 import logging
-import pytest
-import os
 import sys
 from pathlib import Path
+
+import pytest
 
 from avi_py.avi_image_data import AviImageData
 from avi_py import constants as avi_const
@@ -13,19 +13,22 @@ logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 def get_image_data(image_path: str) -> AviImageData:
     return AviImageData(image_path)
 
-@pytest.fixture
-def grayscaled_image_data() -> AviImageData:
+@pytest.fixture(name='grayscaled_image_data')
+def fixture_grayscaled_image_data() -> AviImageData:
     return get_image_data(file_fixtures.GRAYSCALED_IMAGE)
 
-@pytest.fixture
-def srgb_image_data() -> AviImageData:
+@pytest.fixture(name='srgb_image_data')
+def fixture_srgb_image_data() -> AviImageData:
     return get_image_data(file_fixtures.SRGB_IMAGE)
 
-@pytest.fixture
-def no_icc_profile_image() -> AviImageData:
+@pytest.fixture(name='no_icc_profile_image')
+def fixture_no_icc_profile_image() -> AviImageData:
     return get_image_data(file_fixtures.NO_ICC_IMAGE)
 
 class TestAviImageData:
+    """
+    Unit tests for the AviImageData class
+    """
     def test_grayscaled_image_data(self, grayscaled_image_data):
         assert isinstance(grayscaled_image_data, AviImageData)
 

--- a/tests/test_avi_jp2_processor.py
+++ b/tests/test_avi_jp2_processor.py
@@ -1,11 +1,10 @@
 import logging
-import pytest
-import os
 import sys
 import json
-
 from tempfile import TemporaryDirectory, NamedTemporaryFile
-from pathlib import Path
+
+import pytest
+
 from image_processing import conversion
 from image_processing.kakadu import Kakadu
 from avi_py.avi_jp2_processor import AviJp2Processor
@@ -15,36 +14,35 @@ from . import file_fixtures
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
-@pytest.fixture(scope='module')
-def temp_folder(prefix='avi_test_image_files', dir='/tmp'):
-    temp_dir = TemporaryDirectory(prefix=prefix, dir=dir)
-    print(f'Created temp file at {temp_dir.name}')
-    yield temp_dir.name
-    temp_dir.cleanup()
+@pytest.fixture(scope='module', name='temp_folder')
+def fixture_temp_folder():
+    with TemporaryDirectory(prefix='avi_test_image_files', dir='/tmp') as temp_dir:
+        print(f'Created temp file at {temp_dir}')
+        yield temp_dir
 
-@pytest.fixture
-def grayscaled_destination_file(temp_folder):
-    dest_file = NamedTemporaryFile(dir=temp_folder, prefix='test-grayscaled-image',suffix='.jp2')
-    print(f'Created temp file at {dest_file.name}')
-    yield dest_file.name
-    dest_file.close()
+@pytest.fixture(name='grayscaled_destination_file')
+def fixture_grayscaled_destination_file(temp_folder):
+    with NamedTemporaryFile(dir=temp_folder, prefix='test-grayscaled-image', suffix='.jp2') as dest_file:
+        print(f'Created temp file at {dest_file.name}')
+        yield dest_file.name
 
-@pytest.fixture
-def srgb_destination_file(temp_folder):
-    dest_file = NamedTemporaryFile(dir=temp_folder, prefix='test-srgb-image',suffix='.jp2')
-    print(f'Created temp file at {dest_file.name}')
-    yield dest_file.name
-    dest_file.close()
+@pytest.fixture(name='srgb_destination_file')
+def fixture_srgb_destination_file(temp_folder):
+    with NamedTemporaryFile(dir=temp_folder, prefix='test-srgb-image', suffix='.jp2') as dest_file:
+        print(f'Created temp file at {dest_file.name}')
+        yield dest_file.name
 
-@pytest.fixture
-def no_icc_destination_file(temp_folder):
-    dest_file = NamedTemporaryFile(dir=temp_folder, prefix='test-no-icc-image',suffix='.jp2')
-    print(f'Created temp file at {dest_file.name}')
-    yield dest_file.name
-    dest_file.close()
+@pytest.fixture(name='no_icc_destination_file')
+def fixture_no_icc_destination_file(temp_folder):
+    with NamedTemporaryFile(dir=temp_folder, prefix='test-no-icc-image', suffix='.jp2') as dest_file:
+        print(f'Created temp file at {dest_file.name}')
+        yield dest_file.name
 
 class TestAviJp2Convert:
-    def test_grayscaled_image_convert(self, temp_folder, grayscaled_destination_file):
+    """
+    Tests for processing various tiffs to jp2s AviJp2Processor class
+    """
+    def test_grayscaled_image_convert(self, grayscaled_destination_file):
         grayscaled_image_convert = AviJp2Processor.process_jp2(file_fixtures.GRAYSCALED_IMAGE, destination_file=grayscaled_destination_file)
 
         assert isinstance(grayscaled_image_convert, AviJp2Processor)
@@ -60,8 +58,7 @@ class TestAviJp2Convert:
         assert isinstance(grayscaled_image_convert.result_message, str)
         assert isinstance(grayscaled_image_convert.result, dict)
 
-        for key in ['success', 'message']:
-            assert key in grayscaled_image_convert.result.keys()
+        assert all(key in grayscaled_image_convert.result for key in ['success', 'message'])
 
         assert grayscaled_image_convert.success is True
         assert grayscaled_image_convert.success == grayscaled_image_convert.result.get('success')
@@ -72,7 +69,7 @@ class TestAviJp2Convert:
         assert isinstance(grayscaled_image_convert.json_result(), str)
         assert grayscaled_image_convert.json_result() == json.dumps(grayscaled_image_convert.result)
 
-    def test_srgb_image_convert(self, temp_folder, srgb_destination_file):
+    def test_srgb_image_convert(self, srgb_destination_file):
         srgb_image_convert = AviJp2Processor.process_jp2(file_fixtures.SRGB_IMAGE, srgb_destination_file)
 
         assert isinstance(srgb_image_convert, AviJp2Processor)
@@ -87,8 +84,7 @@ class TestAviJp2Convert:
         assert isinstance(srgb_image_convert.result_message, str)
         assert isinstance(srgb_image_convert.result, dict)
 
-        for key in ['success', 'message']:
-            assert key in srgb_image_convert.result.keys()
+        assert all(key in srgb_image_convert.result for key in ['success', 'message'])
 
         assert srgb_image_convert.success is True
         assert srgb_image_convert.success == srgb_image_convert.result.get('success')
@@ -99,7 +95,7 @@ class TestAviJp2Convert:
         assert isinstance(srgb_image_convert.json_result(), str)
         assert srgb_image_convert.json_result() == json.dumps(srgb_image_convert.result)
 
-    def test_no_icc_image_convert(self, temp_folder, no_icc_destination_file):
+    def test_no_icc_image_convert(self, no_icc_destination_file):
         no_icc_image_convert = AviJp2Processor.process_jp2(file_fixtures.NO_ICC_IMAGE, no_icc_destination_file)
 
         assert isinstance(no_icc_image_convert, AviJp2Processor)
@@ -114,8 +110,7 @@ class TestAviJp2Convert:
         assert isinstance(no_icc_image_convert.result_message, str)
         assert isinstance(no_icc_image_convert.result, dict)
 
-        for key in ['success', 'message']:
-            assert key in no_icc_image_convert.result.keys()
+        assert all(key in no_icc_image_convert.result for key in ['success', 'message'])
 
         assert no_icc_image_convert.success is True
         assert no_icc_image_convert.success == no_icc_image_convert.result.get('success')

--- a/tests/test_avi_video_data.py
+++ b/tests/test_avi_video_data.py
@@ -4,6 +4,7 @@ import os
 import sys
 from pathlib import Path
 
+from avi_py.avi_ffprobe_data import AviFfprobeData
 from avi_py.avi_video_data import AviVideoData
 from avi_py import constants as avi_const
 from . import file_fixtures
@@ -23,7 +24,9 @@ def mp4_video_data() -> AviVideoData:
 
 class TestAviImageData:
     def test_mov_video_data(self, mov_video_data):
+        assert bool(mov_video_data) is True
         assert isinstance(mov_video_data, AviVideoData)
+        assert issubclass(mov_video_data.__class__, AviFfprobeData)
         assert isinstance(mov_video_data.video_src_path, Path)
 
         assert str(mov_video_data.video_src_path) == file_fixtures.MOV_VIDEO
@@ -32,38 +35,40 @@ class TestAviImageData:
         assert mov_video_data.video_ext == '.mov'
         assert mov_video_data.valid_video_ext() is True
 
-        assert isinstance(mov_video_data.ffmpeg_probe, dict)
         assert bool(mov_video_data.ffmpeg_probe) is True
+        assert isinstance(mov_video_data.ffmpeg_probe, dict)
 
         for key in ['format', 'streams']:
             assert key in mov_video_data.ffmpeg_probe.keys()
 
-        assert isinstance(mov_video_data.ffprobe_format, dict)
         assert bool(mov_video_data.ffprobe_format) is True
+        assert isinstance(mov_video_data.ffprobe_format, dict)
 
+        assert bool(mov_video_data.ffprobe_streams) is True
         assert isinstance(mov_video_data.ffprobe_streams, list)
-        assert bool(mov_video_data) is True
 
         for stream in mov_video_data.ffprobe_streams:
+            assert bool(stream) is True
             assert isinstance(stream, dict)
-            assert bool(dict) is True
 
-        assert isinstance(mov_video_data.video_stream, dict)
         assert bool(mov_video_data.video_stream) is True
+        assert isinstance(mov_video_data.video_stream, dict)
 
-        assert isinstance(mov_video_data.audio_streams, list)
         assert bool(mov_video_data.audio_streams) is True
+        assert isinstance(mov_video_data.audio_streams, list)
 
-        assert isinstance(mov_video_data.raw_stream, dict)
         assert bool(mov_video_data.raw_stream) is True
+        assert isinstance(mov_video_data.raw_stream, dict)
 
         for audio_stream in mov_video_data.audio_streams:
-            assert isinstance(audio_stream, dict)
             assert bool(audio_stream) is True
+            assert isinstance(audio_stream, dict)
         assert isinstance(mov_video_data.ss_time(), int)
 
     def test_mp4_video_datat(self, mp4_video_data):
+        assert bool(mp4_video_data) is True
         assert isinstance(mp4_video_data, AviVideoData)
+        assert issubclass(mp4_video_data.__class__, AviFfprobeData)
         assert isinstance(mp4_video_data.video_src_path, Path)
 
         assert str(mp4_video_data.video_src_path) == file_fixtures.MP4_VIDEO
@@ -72,32 +77,32 @@ class TestAviImageData:
         assert mp4_video_data.video_ext == '.mp4'
         assert mp4_video_data.valid_video_ext() is True
 
-        assert isinstance(mp4_video_data.ffmpeg_probe, dict)
         assert bool(mp4_video_data.ffmpeg_probe) is True
+        assert isinstance(mp4_video_data.ffmpeg_probe, dict)
 
         for key in ['format', 'streams']:
             assert key in mp4_video_data.ffmpeg_probe.keys()
 
-        assert isinstance(mp4_video_data.ffprobe_format, dict)
         assert bool(mp4_video_data.ffprobe_format) is True
+        assert isinstance(mp4_video_data.ffprobe_format, dict)
 
+        assert bool(mp4_video_data.ffprobe_streams) is True
         assert isinstance(mp4_video_data.ffprobe_streams, list)
-        assert bool(mp4_video_data) is True
 
         for stream in mp4_video_data.ffprobe_streams:
+            assert bool(stream) is True
             assert isinstance(stream, dict)
-            assert bool(dict) is True
 
-        assert isinstance(mp4_video_data.video_stream, dict)
         assert bool(mp4_video_data.video_stream) is True
+        assert isinstance(mp4_video_data.video_stream, dict)
 
-        assert isinstance(mp4_video_data.audio_streams, list)
         assert bool(mp4_video_data.audio_streams) is True
+        assert isinstance(mp4_video_data.audio_streams, list)
 
-        assert isinstance(mp4_video_data.raw_stream, dict)
         assert bool(mp4_video_data.raw_stream) is True
+        assert isinstance(mp4_video_data.raw_stream, dict)
 
         for audio_stream in mp4_video_data.audio_streams:
-            assert isinstance(audio_stream, dict)
             assert bool(audio_stream) is True
+            assert isinstance(audio_stream, dict)
         assert isinstance(mp4_video_data.ss_time(), int)

--- a/tests/test_avi_video_data.py
+++ b/tests/test_avi_video_data.py
@@ -1,12 +1,11 @@
 import logging
-import pytest
-import os
 import sys
 from pathlib import Path
 
-from avi_py.avi_ffprobe_data import AviFfprobeData
+import pytest
+
+from avi_py.avi_ffprobe_data import AviFFProbeData
 from avi_py.avi_video_data import AviVideoData
-from avi_py import constants as avi_const
 from . import file_fixtures
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
@@ -14,19 +13,22 @@ logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 def get_video_data(video_src_path) -> AviVideoData:
     return AviVideoData(video_src_path)
 
-@pytest.fixture
-def mov_video_data() -> AviVideoData:
-    return AviVideoData(file_fixtures.MOV_VIDEO)
+@pytest.fixture(name='mov_video_data')
+def fixture_mov_video_data() -> AviVideoData:
+    return get_video_data(file_fixtures.MOV_VIDEO)
 
-@pytest.fixture
-def mp4_video_data() -> AviVideoData:
-    return AviVideoData(file_fixtures.MP4_VIDEO)
+@pytest.fixture(name='mp4_video_data')
+def fixture_mp4_video_data() -> AviVideoData:
+    return get_video_data(file_fixtures.MP4_VIDEO)
 
-class TestAviImageData:
+class TestAviVideoData:
+    """
+    Unit tests for the AviVideoData class
+    """
     def test_mov_video_data(self, mov_video_data):
         assert bool(mov_video_data) is True
         assert isinstance(mov_video_data, AviVideoData)
-        assert issubclass(mov_video_data.__class__, AviFfprobeData)
+        assert issubclass(mov_video_data.__class__, AviFFProbeData)
         assert isinstance(mov_video_data.video_src_path, Path)
 
         assert str(mov_video_data.video_src_path) == file_fixtures.MOV_VIDEO
@@ -65,10 +67,10 @@ class TestAviImageData:
             assert isinstance(audio_stream, dict)
         assert isinstance(mov_video_data.ss_time(), int)
 
-    def test_mp4_video_datat(self, mp4_video_data):
+    def test_mp4_video_data(self, mp4_video_data):
         assert bool(mp4_video_data) is True
         assert isinstance(mp4_video_data, AviVideoData)
-        assert issubclass(mp4_video_data.__class__, AviFfprobeData)
+        assert issubclass(mp4_video_data.__class__, AviFFProbeData)
         assert isinstance(mp4_video_data.video_src_path, Path)
 
         assert str(mp4_video_data.video_src_path) == file_fixtures.MP4_VIDEO


### PR DESCRIPTION
- Added ability to process `mp3` derivatives, from `wav` files to AviFFMpegProcessor class.
- Added base class for `ffprobe` related data called `AviFFProbeData` which is inherited by `AviVideoData` and new `AviAudioData` classes.
- Various tweaks to test classes.
- Resolves #5 