### PR TITLE
Updated image-processing package version

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,13 +11,13 @@ avi_ocr = 'bin/avi_ocr'
 
 [packages]
 opencv-python = ">3.4"
-image-processing = {editable = true, ref = "1.10.0", git = "https://github.com/bodleian/image-processing.git"}
 urllib3 = ">=2.0.6"
 pillow = "~=10.0.1"
 ffmpeg-python = ">=0.2.0"
 numpy = ">=1.23"
 pytesseract = "~=0.3"
 dill = "~=0.3"
+image-processing = {editable = true, ref = "1.11.0", git = "git+https://github.com/bodleian/image-processing.git"}
 
 [dev-packages]
 pytest = ">=7.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b624df61959bf7ab1fc5e35aeeb48aa9d814ba930c68168057324cf0e2ea4a49"
+            "sha256": "e4941da596942c7d69306bf480db0799f4deab3b6f91bb856497102391a50fe6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -42,9 +42,9 @@
         },
         "image-processing": {
             "editable": true,
-            "git": "https://github.com/bodleian/image-processing.git",
+            "git": "git+https://github.com/bodleian/image-processing.git",
             "markers": "python_version >= '3.5'",
-            "ref": "dc4364a6938d2eaf34efbbdbc1b662cae596a81f"
+            "ref": "b697d84f3eecf175e0f8bdac6efdf55b578244ce"
         },
         "jpylyzer": {
             "hashes": [

--- a/avi_py/avi_jp2_processor.py
+++ b/avi_py/avi_jp2_processor.py
@@ -8,14 +8,13 @@ import logging
 import subprocess
 import json
 import os
-import io
 from pathlib import Path
 from typing import Union
 from image_processing.exceptions import KakaduError, ValidationError, ImageProcessingError
 from image_processing import validation, kakadu
 from image_processing.conversion import Converter
 from image_processing.kakadu import Kakadu
-from PIL import Image, ImageCms
+from PIL import Image
 from PIL.ImageCms import PyCMSError
 from . import constants as avi_const
 from .avi_image_data import AviImageData
@@ -61,41 +60,6 @@ class AviConverter(Converter):
         except subprocess.CalledProcessError as error:
             raise ImageProcessingError('Exiftool at {0} failed to copy from {1}. Command: {2}, Error: {3}'.
                                        format(self.exiftool_path, input_image_filepath, ' '.join(command_options), error))
-
-    def convert_icc_profile(self, image_filepath, output_filepath, icc_profile_filepath, new_colour_mode=None):
-        """
-        Convert the image to a new icc profile. This is lossy, so should only be done when necessary (e.g. if jp2 doesn't support the colour profile)
-        Doesn't support 16bit images due to limitations of Pillow
-
-        Uses the perceptual rendering intent, as it's the recommended one for general photographic purposes, and loses less information on out-of-gamut colours than relative colormetric
-        However, if we're converting to a matrix profile like AdobeRGB, this will use relative colormetric instead, as perceptual intents are only supported by lookup table colour profiles
-        In practise, we should be converting to a wide gamut profile, so out-of-gamut colours will be limited anyway
-        :param image_filepath:
-        :param output_filepath:
-        :param icc_profile_filepath:
-        :param new_colour_mode:
-        :return:
-        """
-        with Image.open(image_filepath) as input_pil:
-            # BitsPerSample is 258 (see PIL.TiffTags.TAGS_V2). tag_v2 is populated when opening an image, but not when saving
-            orig_bit_depths = input_pil.tag_v2[258]
-
-            if orig_bit_depths not in [(8, 8, 8, 8), (8, 8, 8), (8,), (1,)]:
-                raise ImageProcessingError("ICC profile conversion was unsuccessful for {0}: unsupported bit depth {1} "
-                                          "Note: Pillow does not support 16 bit image profile conversion."
-                                          .format(image_filepath, orig_bit_depths))
-
-            input_icc_obj = input_pil.info.get('icc_profile')
-
-            if input_icc_obj is None:
-                raise ImageProcessingError("Image doesn't have a profile")
-
-            input_profile = ImageCms.getOpenProfile(io.BytesIO(input_icc_obj))
-            output_pil = ImageCms.profileToProfile(input_pil, input_profile, icc_profile_filepath,
-                                                  renderingIntent=ImageCms.Intent.PERCEPTUAL,
-                                                  outputMode=new_colour_mode, inPlace=0)
-            output_pil.save(output_filepath)
-            self.copy_over_embedded_metadata(image_filepath, output_filepath)
 #pylint: enable=raise-missing-from
 
 


### PR DESCRIPTION
- Updated `image-processing` package version to `1.11.0`
- Removed overloaded method in `AviConverter` class in `avi_jp2_processing` module due to the fix in the updated package
- Ran tests and linting locally to ensure they passed